### PR TITLE
[gen by codex] docs: refresh README and add git PR merge skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,272 +2,276 @@
 
 > English version: [README.en.md](./README.en.md)
 
-올바른정형외과의 환자 대기열을 실시간으로 관리하는 웹 애플리케이션입니다. 환자 접수부터 대기 현황 확인, 관리자 대시보드까지 모든 기능을 제공합니다.
+올바른정형외과의 환자 대기열과 예약을 관리하는 웹 애플리케이션입니다. 환자 접수, 환자용 대기 현황 조회, 기존 환자 예약, 관리자 대시보드 및 마스터 관리 기능을 제공합니다.
 
-## 🚀 주요 기능
+## 2026-03-20 기준 구현 진행상황
+
+### 현재 구현 완료
+
+- 환자 접수: 이름/나이/진료항목 검증, 담당의 선택 시 진료실 자동 반영, 대기열 등록, 고유 링크 생성
+- 접수 완료 후 링크 복사, 대기열 바로가기, QR 코드 생성/이미지 복사/다운로드
+- 환자용 대기열 조회: ETA, 진행률, 상태 표시, 수동 새로고침, 마지막 업데이트 시간 표시
+- 환자용 대기열 자동 폴링: 1분 주기
+- 진료항목별 남은 대기시간 집계 표시
+- 기존 환자 예약: 방문 이력 확인, 날짜/시간 선택, 정원 제한, 예약 완료 후 복사/공유
+- 관리자 로그인: `ADMIN_SECRET` 기반 비밀번호 로그인, 미들웨어 보호, 관리자 API 인증
+- 관리자 대시보드: 대기열 목록 조회, 수정, 삭제, 30초 자동 새로고침, 통계 카드
+- 관리자 마스터 관리: 진료항목/의료진/환자 CRUD, 활성/비활성 토글
+- 관리자 예약 관리: 예약 목록 조회, 날짜 필터, 수정, 삭제
+- 관리자 예약 정원 설정: 서비스/요일별 규칙 CRUD 및 활성화 제어
+- 진료항목 CSV 업로드 기반 예상 대기시간 자동 산출 및 적용
+
+### 부분 구현
+
+- 관리자 대시보드 인라인 수정은 동작하지만 optimistic update는 없고 저장 후 재조회 방식입니다.
+- 진료항목 관리에서 예상 대기시간을 수정할 수 있지만, 현재 환자 접수 API 계산은 여전히 서버 상수값을 사용합니다.
+- 예약 화면의 서비스 목록과 예약 생성 로직은 관리자 진료항목 설정과 완전히 연결돼 있지 않습니다.
+- 예약 정원 설정은 동작하지만 저장 위치는 서버 DB가 아닌 브라우저 `localStorage`입니다.
+
+### 화면은 있으나 기능적으로는 미완성
+
+- 환자용 대기열의 "알림 설정" 탭은 UI 상태 전환만 있고 실제 문자/푸시 연동은 없습니다.
+- 관리자 설정 화면은 UI만 있으며 저장, 백업, 초기화, 서버 연동이 없습니다.
+- 관리자 대시보드 차트는 실제 운영 데이터가 아니라 샘플 데이터입니다.
+- 관리자 대시보드의 "완료 처리" 기능은 코드 함수는 있으나 현재 화면 버튼이 연결돼 있지 않습니다.
+
+### 아직 미구현
+
+- Redis 기반 실시간 저장소
+- PostgreSQL 스키마/마이그레이션
+- 설정 서버 영속화
+- SMS/Kakao 알림 연동
+- 환자 토큰 검증 미들웨어 고도화
+- 실제 운영 지표 기반 통계 차트
+- 배포/백업/모니터링 파이프라인
+
+### 현재 저장 구조
+
+- 대기열: 서버 메모리 저장소
+- 예약/진료항목/의료진/환자/예약 정원 규칙: 브라우저 `localStorage`
+
+### 현재 확인된 품질 상태
+
+- `pnpm test`: 통과
+- `pnpm lint`: 경고만 존재
+- `pnpm build`: 성공
+
+### 다음 우선순위 권장
+
+1. 관리자에서 수정한 진료항목 대기시간이 실제 접수/예약 계산에 반영되도록 연결
+2. UI-only 기능(설정, 알림, 차트, 완료 처리 버튼) 정리
+3. 메모리/`localStorage` 저장을 Redis/PostgreSQL로 전환
+
+## 주요 기능
 
 ### 환자 접수 시스템
 
-- **환자 정보 입력**: 이름, 나이, 진료실, 담당의 정보 등록
-- **진료 항목 선택**: 일반진료(10분), 재진(5분), 검사(15분), 처방(3분)
-- **고유 링크 생성**: 각 환자마다 개인별 대기열 확인 링크 발급
-- **링크 공유**: 복사 및 바로가기 기능으로 환자에게 쉽게 전달
+- 환자 정보 입력: 이름, 나이, 진료실, 담당의 정보 등록
+- 진료 항목 선택: 기본 진료항목 및 관리자 설정 항목 사용
+- 고유 링크 생성: 각 환자마다 개인별 대기열 확인 링크 발급
+- 링크/QR 공유: 링크 복사, 바로가기, QR 이미지 복사/다운로드 지원
 
-### 실시간 대기열 조회
+### 환자용 대기열 조회
 
-- **3분 자동 업데이트**: 실시간으로 대기 시간 갱신
-- **진행률 표시**: 시각적 진행률 바로 대기 상황 확인
-- **모바일 최적화**: 반응형 디자인으로 모든 기기에서 사용 가능
-- **접근성 지원**: 모션 감소 설정, ARIA 라벨 등 접근성 고려
+- 1분 자동 업데이트: 대기 시간과 상태 자동 갱신
+- 진행률 표시: 시각적 진행률로 현재 대기 상황 확인
+- 임박 알림: ETA 5분 이하 경고 및 ETA 0분 이하 상태 강조
+- 진료항목별 남은 대기시간 집계 표시
+- 모바일 최적화 및 접근성 고려
 
-### 관리자 대시보드
+### 예약 시스템
 
-- **실시간 모니터링**: 현재 대기 중인 모든 환자 현황
-- **환자 정보 관리**: 이름, 나이, 진료실, 담당의, 진료항목, 대기시간 수정
-- **대기열 삭제**: 완료된 환자 대기열 제거
-- **통계 정보**: 전체 대기, 임박 환자(5분 이내), 완료 환자 수 표시
-- **30초 자동 새로고침**: 실시간 데이터 업데이트
+- 기존 환자 확인: 환자 ID/이름/전화번호 기반 방문 이력 검증
+- 날짜 및 시간대 선택: 과거 날짜 차단, 시간대별 정원 반영
+- 예약 요약 제공: 예약번호, 예상 대기시간, 복사/공유 지원
+- 관리자 예약 관리: 수정, 삭제, 날짜 필터링
 
-## 🛠 기술 스택
+### 관리자 기능
+
+- 로그인 보호: `/admin/*` 경로 미들웨어 보호
+- 실시간 모니터링: 현재 대기열 조회 및 30초 자동 새로고침
+- 대기열 관리: 환자 정보 수정 및 삭제
+- 마스터 관리: 진료항목, 의료진, 환자 CRUD
+- 예약 정원 관리: 서비스/요일별 규칙 설정
+- CSV 업로드: 진료항목별 예상 대기시간 자동 산출 및 적용
+
+## 기술 스택
 
 ### Frontend
 
-- **Next.js 15.5.0** - App Router 기반 React 프레임워크
-- **TypeScript 5** - 타입 안전성 보장
-- **Tailwind CSS 4** - 유틸리티 기반 CSS 프레임워크
-- **shadcn/ui** - Radix UI 기반 컴포넌트 라이브러리
-- **Framer Motion** - 부드러운 애니메이션 효과
+- Next.js 15.5.7
+- React 19
+- TypeScript 5
+- Tailwind CSS 4
+- shadcn/ui
+- Framer Motion
+- Recharts
 
 ### State Management & Data Fetching
 
-- **TanStack React Query** - 서버 상태 관리 및 폴링
-- **React Hooks** - 로컬 상태 관리
+- TanStack React Query
+- React Hooks
 
 ### Development Tools
 
-- **ESLint** - 코드 품질 관리
-- **Prettier** - 코드 포맷팅
-- **pnpm** - 패키지 매니저
+- ESLint
+- Prettier
+- Vitest
+- pnpm
 
-## 📁 프로젝트 구조
+## 현재 아키텍처 요약
 
-```
+- App Router 기반 단일 Next.js 앱
+- API Route Handler: [src/app/api/queue/route.ts](/Users/jisung/Projects/allright/allright-queue/src/app/api/queue/route.ts)
+- 관리자 인증 API: [src/app/api/admin/auth/route.ts](/Users/jisung/Projects/allright/allright-queue/src/app/api/admin/auth/route.ts)
+- 관리자 보호 미들웨어: [middleware.ts](/Users/jisung/Projects/allright/allright-queue/middleware.ts)
+- 대기열 저장소: 메모리 기반 `Map`
+- 예약/마스터 데이터 저장소: `localStorage`
+
+## 프로젝트 구조
+
+```text
 allright-queue/
 ├── src/
-│   ├── app/                      # Next.js App Router
-│   │   ├── layout.tsx            # 루트 레이아웃
-│   │   ├── page.tsx              # 홈페이지 (메인 대시보드)
-│   │   ├── globals.css           # 전역 스타일
-│   │   ├── providers.tsx         # React Query Provider
-│   │   ├── register/
-│   │   │   └── page.tsx          # 환자 접수 페이지
-│   │   ├── queue/
-│   │   │   └── page.tsx          # 대기열 조회 페이지
-│   │   ├── admin/                # 관리자 섹션
-│   │   │   ├── layout.tsx        # 관리자 레이아웃
-│   │   │   ├── page.tsx          # 관리자 대시보드
-│   │   │   ├── doctors/
-│   │   │   │   └── page.tsx      # 의사 관리 페이지
-│   │   │   ├── patients/
-│   │   │   │   └── page.tsx      # 환자 관리 페이지
-│   │   │   ├── services/
-│   │   │   │   └── page.tsx      # 서비스 관리 페이지
-│   │   │   └── settings/
-│   │   │       └── page.tsx      # 설정 페이지
+│   ├── app/
+│   │   ├── page.tsx
+│   │   ├── register/page.tsx
+│   │   ├── queue/page.tsx
+│   │   ├── reservation/page.tsx
+│   │   ├── admin/
+│   │   │   ├── login/page.tsx
+│   │   │   ├── page.tsx
+│   │   │   ├── services/page.tsx
+│   │   │   ├── doctors/page.tsx
+│   │   │   ├── patients/page.tsx
+│   │   │   ├── reservations/page.tsx
+│   │   │   ├── reservations/capacity/page.tsx
+│   │   │   └── settings/page.tsx
 │   │   └── api/
-│   │       └── queue/
-│   │           └── route.ts      # 대기열 API 엔드포인트
+│   │       ├── queue/route.ts
+│   │       └── admin/auth/route.ts
 │   ├── components/
-│   │   └── ui/                   # shadcn/ui 컴포넌트들
-│   │       ├── alert.tsx
-│   │       ├── badge.tsx
-│   │       ├── button.tsx
-│   │       ├── card.tsx
-│   │       ├── input.tsx
-│   │       ├── label.tsx
-│   │       ├── progress.tsx
-│   │       ├── select.tsx
-│   │       ├── separator.tsx
-│   │       ├── switch.tsx
-│   │       └── tabs.tsx
-│   └── lib/
-│       ├── useQueue.ts           # 대기열 관련 커스텀 훅
-│       └── utils.ts              # 유틸리티 함수들
-├── public/                       # 정적 파일들
-│   ├── file.svg
-│   ├── globe.svg
-│   ├── next.svg
-│   ├── vercel.svg
-│   └── window.svg
-├── .cursor/                      # Cursor IDE 설정
-├── .cursorrules                  # Cursor IDE 규칙
-├── components.json               # shadcn/ui 설정
-├── eslint.config.mjs             # ESLint 설정
-├── next.config.ts                # Next.js 설정
-├── postcss.config.mjs            # PostCSS 설정
-├── tailwind.config.ts            # Tailwind CSS 설정
-├── tsconfig.json                 # TypeScript 설정
-└── package.json                  # 프로젝트 의존성 및 스크립트
+│   │   ├── charts/
+│   │   └── ui/
+│   ├── lib/
+│   └── types/
+├── middleware.ts
+├── prompt/prd.md
+├── AGENTS.md
+└── README.md
 ```
 
-## 🚀 시작하기
+## 시작하기
 
 ### 환경 요구사항
 
 - Node.js v22.18.0 이상
-- pnpm 패키지 매니저
+- pnpm
 
 ### 설치 및 실행
 
-1. **의존성 설치**
+```bash
+pnpm install
+pnpm dev
+```
 
-   ```bash
-   pnpm install
-   ```
+브라우저에서 [http://localhost:3000](http://localhost:3000) 을 열면 됩니다.
 
-2. **개발 서버 실행**
-
-   ```bash
-   pnpm dev
-   ```
-
-3. **브라우저에서 확인**
-   ```
-   http://localhost:3000
-   ```
-
-### 빌드 및 배포
+### 빌드 및 실행
 
 ```bash
-# 프로덕션 빌드
 pnpm build
-
-# 프로덕션 서버 실행
 pnpm start
 ```
 
-## 📖 사용 방법
+## 주요 페이지
 
-### 1. 환자 접수
+### 환자용
 
-1. 홈페이지에서 "접수 시작" 클릭
-2. 환자 정보 입력 (이름, 나이, 진료실, 담당의)
-3. 진료 항목 선택
-4. "접수 완료" 클릭
-5. 생성된 고유 링크를 환자에게 전달
+- `/` 메인 화면
+- `/register` 환자 접수
+- `/queue?token=...` 환자별 대기열 조회
+- `/reservation` 기존 환자 예약
 
-### 2. 대기열 확인 (환자용)
+### 관리자용
 
-1. 접수 시 받은 링크로 접속
-2. 실시간 대기 시간 및 진행률 확인
-3. 3분마다 자동으로 정보 업데이트
+- `/admin/login` 관리자 로그인
+- `/admin` 관리자 대시보드
+- `/admin/services` 진료항목 관리
+- `/admin/doctors` 의료진 관리
+- `/admin/patients` 환자 관리
+- `/admin/reservations` 예약 관리
+- `/admin/reservations/capacity` 예약 정원 설정
+- `/admin/settings` 설정 화면(UI-only)
 
-### 3. 관리자 대시보드
+## API 엔드포인트
 
-1. 홈페이지에서 "대시보드 열기" 클릭
-2. 현재 대기 중인 모든 환자 현황 확인
-3. 환자 정보 수정 또는 삭제
-4. 통계 정보 모니터링
+### 대기열 API (`/api/queue`)
 
-## 🔧 API 엔드포인트
+- `GET ?token={token}`: 환자 대기열 조회
+- `GET ?action=serviceWaitTimes`: 진료항목별 남은 대기시간 집계 조회
+- `POST`: 새로운 대기열 등록
+- `PUT`: 대기열 수정(관리자 인증 필요)
+- `DELETE ?token={token}`: 대기열 삭제(관리자 인증 필요)
+- `PATCH ?action=list`: 전체 대기열 목록 조회(관리자 인증 필요)
 
-### 대기열 관리 API (`/api/queue`)
+### 관리자 인증 API (`/api/admin/auth`)
 
-- **GET** `?token={token}` - 대기열 상태 조회
-- **POST** - 새로운 대기열 등록
-- **PUT** - 대기열 정보 업데이트
-- **DELETE** `?token={token}` - 대기열 삭제
-- **PATCH** `?action=list` - 관리자용 전체 대기열 목록
+- `POST`: 관리자 로그인
+- `DELETE`: 관리자 로그아웃
 
-## 🎨 UI/UX 특징
-
-- **한국어 인터페이스**: 의료 환경에 최적화된 한국어 UI
-- **모바일 우선**: 모바일 기기에서 최적의 사용자 경험
-- **접근성**: 키보드 네비게이션, 스크린 리더 지원
-- **애니메이션**: 부드러운 전환 효과 (모션 감소 설정 지원)
-- **실시간 피드백**: 로딩 상태, 에러 처리, 성공 메시지
-
-## 🔒 보안 및 데이터
-
-- **고유 토큰**: 각 환자마다 고유한 대기열 토큰 생성
-- **URL 인코딩**: 안전한 URL 파라미터 처리
-- **에러 처리**: 적절한 에러 메시지 및 복구 방법 제공
-- **데이터 검증**: 입력 데이터 유효성 검사
-
-## 🚧 개발 환경
-
-### 스크립트
-
-```bash
-pnpm dev          # 개발 서버 실행 (Turbopack)
-pnpm build        # 프로덕션 빌드
-pnpm start        # 프로덕션 서버 실행
-pnpm lint         # ESLint 실행
-pnpm format       # Prettier 포맷팅
-pnpm add-component # shadcn/ui 컴포넌트 추가
-```
-
-### 환경 변수
-
-현재는 기본 설정으로 동작하며, 필요시 다음 환경 변수를 추가할 수 있습니다:
+## 환경 변수
 
 ```env
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+ADMIN_SECRET=change-me
+NEXT_PUBLIC_RESERVATION_MAX_PER_SLOT=4
+NEXT_PUBLIC_RESERVATION_MAX_PER_DAY=40
+NEXT_PUBLIC_HOSPITAL_NAME=올바른정형외과
+NEXT_PUBLIC_HOSPITAL_CONTACT=문의: 02-0000-0000
+USE_REDIS=false
+REDIS_URL=
+USE_DB=false
+DATABASE_URL=
 ```
 
-Vitest를 실행할 때는 `.env.test` 파일이 자동으로 로드되므로, 테스트 전용 값이 필요하면 이 파일을 수정하세요.
+Vitest 실행 시 `.env.test` 파일이 자동으로 로드됩니다.
 
-## 🤝 기여하기
+## 개발 명령어
 
-1. 이슈 생성 또는 기존 이슈 확인
-2. 기능 브랜치 생성 (`feature/기능명`)
-3. 코드 작성 및 테스트
-4. Pull Request 생성
+```bash
+pnpm dev
+pnpm build
+pnpm start
+pnpm lint
+pnpm format
+pnpm test
+pnpm add-component
+```
 
-## 📄 라이선스
+## 현재 알려진 제한사항
 
-### 프로젝트 라이선스
+- 서버 재시작 시 메모리 기반 대기열은 초기화됩니다.
+- 브라우저가 바뀌면 `localStorage` 기반 예약/마스터 데이터는 공유되지 않습니다.
+- 관리자 설정값 일부는 실제 계산 로직과 아직 완전히 연결되지 않았습니다.
+- 통계 차트는 운영 데이터가 아닌 샘플 데이터입니다.
+- 설정/알림 일부는 화면만 있고 실제 저장 또는 외부 연동이 없습니다.
 
-이 프로젝트는 **MIT 라이선스** 하에 배포됩니다.
+## 남은 작업 요약
 
-### 의존성 라이선스 검토
+- CSV 업로드 템플릿 샘플 제공 및 다운로드
+- 평균 외 통계 전략(최대값, 표준편차 등) 추가
+- 관리자 UI에서 통계 전략 선택
+- 관리자 대시보드 unused 코드 및 ESLint warning 정리
+- Redis/PostgreSQL 전환
+- 설정 저장 API 및 운영용 백업/모니터링 체계 구축
 
-상업용 배포 시 라이선스 호환성 검토 결과:
+## 참고 문서
 
-#### ✅ 상업용 배포 가능한 라이선스
+- [prompt/prd.md](/Users/jisung/Projects/allright/allright-queue/prompt/prd.md)
+- [AGENTS.md](/Users/jisung/Projects/allright/allright-queue/AGENTS.md)
+- [README.en.md](/Users/jisung/Projects/allright/allright-queue/README.en.md)
 
-- **MIT 라이선스**: Next.js, React, React DOM, Radix UI 컴포넌트들, Framer Motion, TanStack React Query, clsx, tailwind-merge, Tailwind CSS, TypeScript, ESLint, Prettier
-  - 상업용 사용 가능
-  - 라이선스 및 저작권 고지 필요
-  - 수정 및 배포 자유
+## 라이선스
 
-- **ISC 라이선스**: Lucide React
-  - MIT 라이선스와 유사
-  - 상업용 사용 가능
-  - 라이선스 고지 필요
-
-- **Apache-2.0 라이선스**: class-variance-authority
-  - 상업용 사용 가능
-  - 라이선스 및 저작권 고지 필요
-  - 수정 및 배포 자유
-
-#### 📋 라이선스 준수 사항
-
-상업용 배포 시 다음 사항을 준수해야 합니다:
-
-1. **라이선스 고지**: 각 라이브러리의 라이선스 텍스트를 프로젝트에 포함
-2. **저작권 고지**: 원본 저작권자 정보 유지
-3. **라이선스 파일**: `LICENSE` 파일에 프로젝트 라이선스 명시
-4. **의존성 라이선스**: `package.json`에 각 패키지의 라이선스 정보 포함
-
-#### 🚨 주의사항
-
-- 모든 주요 의존성이 상업용 배포에 적합한 라이선스를 사용
-- 라이선스 위반 위험은 **낮음**
-- 단, 라이선스 고지 의무는 반드시 준수해야 함
-
----
-
-**개발**: Jeongjibsa  
-**버전**: 1.0.0  
-**최종 업데이트**: 2025.08.25
+이 프로젝트는 [MIT License](./LICENSE) 하에 배포됩니다.

--- a/skills/git-pr-merge/SKILL.md
+++ b/skills/git-pr-merge/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: git-pr-merge
+description: Commit validated workspace changes, push a branch, create a GitHub pull request, and merge it safely end-to-end. Use when the user wants the current work shipped through git/gh, including commit message creation, branch push, PR opening, PR checks, merge, and post-merge cleanup while respecting repo-specific rules.
+---
+
+# Git PR Merge
+
+Ship already-implemented work through git and GitHub with a consistent, reviewable workflow.
+
+Prefer this skill when the user explicitly wants all of these handled in one flow:
+- commit
+- push
+- PR creation
+- merge
+
+Before acting, read repository-local instructions such as `AGENTS.md`, `README`, contribution docs, or other git workflow notes if they exist.
+
+## Preconditions
+
+Confirm these before changing git state:
+
+- The user has approved committing and pushing.
+- The current workspace changes are intentional.
+- `git` and `gh` are available.
+- `gh auth status` is valid for the target remote when PR creation or merge is required.
+- Required validation for the repo has already passed, or can be run now.
+
+If any precondition is missing, stop and resolve it before creating commits or PRs.
+
+## Workflow
+
+### 1. Inspect repository state
+
+Run and review:
+
+```bash
+git status --short
+git branch --show-current
+git remote -v
+```
+
+Read repo instructions that affect git flow, such as:
+- branch naming rules
+- commit message conventions
+- PR title/body conventions
+- required checks
+- auto-generated PR labeling rules
+
+If running inside Codex and a new branch must be created, follow any enforced branch prefix from the environment or repo instructions before pushing.
+
+Never sweep unrelated user changes into the same commit without calling that out explicitly.
+
+### 2. Validate before commit
+
+Run the smallest meaningful validation for the changed files first, then broader checks if needed.
+
+Typical order:
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
+```
+
+If validation fails, fix the issue or report the blocker before committing.
+
+### 3. Stage only the intended changes
+
+Prefer explicit paths over broad staging when possible:
+
+```bash
+git add path/to/file
+git add another/file
+```
+
+Use `git diff --cached --stat` and `git diff --cached` to verify the staged contents match the requested work.
+
+### 4. Create the commit
+
+Write a concrete commit message that matches repo conventions.
+
+Prefer:
+- `feat: ...`
+- `fix: ...`
+- `docs: ...`
+- `refactor: ...`
+- `test: ...`
+- `chore: ...`
+
+Avoid vague messages such as `update`, `changes`, or `fix stuff`.
+
+Use a non-interactive command:
+
+```bash
+git commit -m "feat: concise description"
+```
+
+Do not amend unless the user explicitly asked for it.
+
+### 5. Push the branch
+
+If already on the correct feature branch, push it. If a new branch is needed, follow repo naming rules first.
+
+Example:
+
+```bash
+git push -u origin <branch-name>
+```
+
+If the repo requires a specific prefix, honor it. If instructions conflict with the current branch, create a compliant branch before pushing.
+
+Example branch creation flow:
+
+```bash
+git checkout -b <compliant-branch-name>
+git push -u origin <compliant-branch-name>
+```
+
+### 6. Open the pull request
+
+Use `gh pr create` non-interactively. Build the title/body from the actual diff, not from guesses.
+
+Minimum PR body should include:
+- problem or purpose
+- summary of changes
+- validation performed
+- any remaining risk or follow-up
+
+If the repo requires auto-generated PR conventions, apply them here. Example: title prefix or labels such as `auto-generated`.
+
+Example:
+
+```bash
+gh pr create --title "feat: concise description" --body "..."
+```
+
+After creation, capture and report:
+- PR URL
+- target branch
+- title
+
+### 7. Check PR status before merge
+
+Review:
+
+```bash
+gh pr status
+gh pr checks
+```
+
+If checks are pending, wait or poll.
+If checks fail, inspect, fix, recommit, and push before merging.
+
+Do not merge a failing PR unless the user explicitly instructs it and repo policy allows it.
+
+### 8. Merge safely
+
+Prefer the repo's standard merge strategy. If unclear:
+- use squash merge for single-feature work
+- use merge commit only when preserving commit structure matters
+- use rebase merge only when the repo clearly prefers it
+
+Use a non-interactive command such as:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+If local branch cleanup is still needed after merge, use:
+
+```bash
+git fetch --prune
+git branch -d <branch-name>
+```
+
+## Safeguards
+
+- Never use destructive reset or checkout commands unless explicitly requested.
+- Never include unrelated dirty files just to make the branch clean.
+- Never merge without checking PR state first.
+- Never assume GitHub auth is available; verify it.
+- Prefer explicit dates, branch names, and command results in the final report.
+- If repo instructions and default git habits conflict, follow the repo instructions.
+
+## Final response checklist
+
+Report these items back to the user:
+
+- commit hash and commit message
+- branch name pushed
+- PR URL
+- merge method used
+- final merge result
+- any checks that were run
+- any checks not run or remaining risks

--- a/skills/git-pr-merge/agents/openai.yaml
+++ b/skills/git-pr-merge/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git PR Merge"
+  short_description: "Commit, push, open a PR, and merge safely."
+  default_prompt: "Use $git-pr-merge to commit the current work, push it, open a GitHub PR, and merge it safely."


### PR DESCRIPTION
## Problem
The repository README was out of sync with the implemented state, and there was no reusable project-local skill for commit/push/PR/merge automation.

## Summary
- refresh README to reflect the actual implementation status, partial features, UI-only areas, and remaining work
- add a project-local `git-pr-merge` skill with safeguards for staged commits, push, PR creation, and merge
- include agent metadata for the new skill

## Validation
- did not rerun checks for this PR because the changes are documentation and skill instructions only
- earlier in this session: `pnpm test` passed, `pnpm lint` completed with warnings only, and `pnpm build` succeeded

## Risks / Follow-up
- `skills/git-pr-merge` quick validation script still requires a local Python `yaml` module if automated validation is needed later